### PR TITLE
Use type alias for MQTTnet.Client.IMqttClient

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Extensions/ServiceCollectionExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Extensions/ServiceCollectionExtensions.cs
@@ -2,7 +2,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using MQTTnet;
-using MQTTnet.Client;
+using IMqttNetClient = MQTTnet.Client.IMqttClient;
 
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt.Extensions;
 
@@ -20,7 +20,7 @@ public static class ServiceCollectionExtensions
 
         // Register concrete MqttClient class
         services.AddSingleton(sp => new MqttClient(
-            sp.GetRequiredService<MQTTnet.Client.IMqttClient>(),
+            sp.GetRequiredService<IMqttNetClient>(),
             mqttOptions,
             sp.GetRequiredService<ILogger<MqttClient>>()));
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using MQTTnet;
 using MQTTnet.Client;
 using Polly;
+using IMqttNetClient = MQTTnet.Client.IMqttClient;
 
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt;
 
@@ -15,11 +16,11 @@ public sealed class MqttClient : IHostedService, IMqttClient, IDisposable
     private readonly MqttOptions options;
     private readonly MqttClientOptions clientOptions;
     private readonly ILogger<MqttClient> logger;
-    private readonly MQTTnet.Client.IMqttClient mqttNetClient;
+    private readonly IMqttNetClient mqttNetClient;
 
     private ConcurrentDictionary<string, MqttMessage> backlog = new(StringComparer.Ordinal);
 
-    public MqttClient(MQTTnet.Client.IMqttClient mqttNetClient, MqttOptions options, ILogger<MqttClient> logger)
+    public MqttClient(IMqttNetClient mqttNetClient, MqttOptions options, ILogger<MqttClient> logger)
     {
         this.mqttNetClient = mqttNetClient;
         this.options = options;

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Integration.Tests/MqttClientTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Integration.Tests/MqttClientTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MQTTnet;
 using MQTTnet.Client;
 using MQTTnet.Server;
+using IMqttNetClient = MQTTnet.Client.IMqttClient;
 
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt.Integration.Tests;
 
@@ -93,7 +94,7 @@ public class MqttClientTest
         (await tcs.Task).Should().Be(expected);
     }
 
-    private static async Task<MQTTnet.Client.IMqttClient> CreateTestClientAsync(MqttFactory factory)
+    private static async Task<IMqttNetClient> CreateTestClientAsync(MqttFactory factory)
     {
         var client = factory.CreateMqttClient();
         var clientOptions = new MqttClientOptionsBuilder()
@@ -118,7 +119,7 @@ public class MqttClientTest
     }
 
     private static Task<MqttClientSubscribeResult> SubscribeToTopicAsync(
-        MQTTnet.Client.IMqttClient client,
+        IMqttNetClient client,
         string topic,
         Action<string> onMessageReceived)
     {

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/MqttClientTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/MqttClientTest.cs
@@ -3,10 +3,9 @@ using System.Net.Sockets;
 using System.Text;
 using MQTTnet;
 using MQTTnet.Client;
+using IMqttNetClient = MQTTnet.Client.IMqttClient;
 
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt.Tests;
-
-using IMqttNetClient = MQTTnet.Client.IMqttClient;
 
 public class MqttClientTest
 {


### PR DESCRIPTION
The `MQTTnet.Client.IMqttClient` interface conflicts with `LupusBytes.CS2.GameStateIntegration.Mqtt.IMqttClient` by name.
This PR will use type alias everywhere, instead of partially qualifying it to avoid ambiguousness.