### PR TITLE
Align application version with device firmware version in MQTT discovery protocol.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,11 +7,9 @@
   </PropertyGroup>
 
   <!-- Solution wide properties -->
-  <PropertyGroup Label="Assembly Naming">
-    <Company>$(OrganizationName)</Company>
-    <Authors>$(OrganizationName)</Authors>
-    <NeutralLanguage>en</NeutralLanguage>
-    <DefaultLanguage>en-US</DefaultLanguage>
+  <PropertyGroup Label="Versioning">
+    <Version>1.0.0</Version>
+    <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Compile settings">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,10 @@
 
   <!-- Solution wide properties -->
   <PropertyGroup Label="Versioning">
+    <!-- The 'x-release-please-' comments are used to inform the release-please action that it should update the semver version here -->
+    <!-- x-release-please-start-version -->
     <Version>1.0.0</Version>
+    <!-- x-release-please-end -->
     <IncludeSourceRevisionInInformationalVersion>true</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,5 +6,8 @@
   "packages": {
     ".": {
     }
-  }
+  },
+  "extra-files": [
+    "Directory.Build.props"
+  ]
 }

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/HomeAssistantDevicePublisher.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/HomeAssistantDevicePublisher.cs
@@ -69,7 +69,7 @@ public sealed class HomeAssistantDevicePublisher(
         Name: "CS2",
         Manufacturer: "lupusbytes",
         Model: Constants.ProjectName,
-        SoftwareVersion: "1.0.0");
+        SoftwareVersion: Constants.Version);
 
     private static IDeviceSensors CreateDeviceSensors(BaseEvent @event, Device device) => @event switch
     {

--- a/src/LupusBytes.CS2.GameStateIntegration/Constants.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/Constants.cs
@@ -1,6 +1,13 @@
+using System.Reflection;
+
 namespace LupusBytes.CS2.GameStateIntegration;
 
 public static class Constants
 {
     public const string ProjectName = "cs2mqtt";
+
+    public static string Version { get; } = Assembly
+        .GetExecutingAssembly()
+        .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+        .InformationalVersion ?? "Unknown";
 }


### PR DESCRIPTION
The HomeAssistant MQTT device discovery protocol enables you to specify the firmware version the device is using. It is logical for this version to match our cs2mqtt version.