### PR TITLE
Graceful shutdown MQTT fixes

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
@@ -111,5 +111,15 @@ public sealed class MqttClient : IHostedService, IMqttClient, IDisposable
 
     public Task StartAsync(CancellationToken cancellationToken) => ConnectAsync(ConnectRetryCount, cancellationToken);
 
-    public Task StopAsync(CancellationToken cancellationToken) => mqttNetClient.DisconnectAsync(cancellationToken: cancellationToken);
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        await PublishAsync(
+            new MqttMessage(
+                MqttConstants.SystemAvailabilityTopic,
+                "offline",
+                RetainFlag: true),
+            cancellationToken);
+
+        await mqttNetClient.DisconnectAsync(cancellationToken: cancellationToken);
+    }
 }

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/MqttClientTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/MqttClientTest.cs
@@ -115,7 +115,6 @@ public class MqttClientTest
     [SuppressMessage("Style", "IDE0060:Remove unused parameter", Justification = "sut's event handler is doing work behind the scenes")]
     public Task Attempts_to_reconnect_after_disconnect(
         [Frozen] IMqttNetClient mqttNetClient,
-        [Frozen] MqttOptions options,
         MqttClient sut)
     {
         // Arrange


### PR DESCRIPTION
- Ensure application does not try to reconnect to MQTT broker while shutting down
- Publish offline message to cs2mqtt/status on graceful shutdown