### PR TITLE
fix(homeassistant): use `availability_mode: all` for mqtt entities

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/DiscoveryPayload.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/DiscoveryPayload.cs
@@ -9,4 +9,5 @@ public record DiscoveryPayload(
     [property: JsonPropertyName("value_template")] string ValueTemplate,
     [property: JsonPropertyName("icon")] string Icon,
     [property: JsonPropertyName("device")] Device Device,
-    [property: JsonPropertyName("availability")] IReadOnlyCollection<Availability> Availability);
+    [property: JsonPropertyName("availability")] IReadOnlyCollection<Availability> Availability,
+    [property: JsonPropertyName("availability_mode")] string AvailabilityMode = "all");


### PR DESCRIPTION
When using `availability_mode: all`, all availability topics must report "online" for the device to be considered available. The default mode, `latest`, is incompatible with our current setup. Upon startup, a system-wide online message is published, causing Home Assistant to incorrectly report all previously published devices as online, even if their designated availability topics are offline.