### PR TITLE
Fix .NET 9 analyzer warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -510,4 +510,3 @@ csharp_style_namespace_declarations = file_scoped:warning
 
 dotnet_diagnostic.CA2007.severity = none            # CA2007:Consider calling ConfigureAwait on the awaited task
 dotnet_diagnostic.MA0004.severity = none            # MA0004:Use Task.ConfigureAwait(false)
-dotnet_diagnostic.S1118.severity  = none            # S1118:Utility classes should not have public constructors (needed for minimal api tests)

--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics.CodeAnalysis;
-using System.Text.Json;
 using LupusBytes.CS2.GameStateIntegration.Contracts;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
@@ -59,8 +59,7 @@ public static class EndpointRouteBuilderExtensions
     }
 
     private static void RequireTokenAuthorization(RouteHandlerBuilder builder, string token)
-    {
-        builder.Add(b =>
+        => builder.Add(b =>
         {
             var originalHandler = b.RequestDelegate;
 
@@ -71,7 +70,6 @@ public static class EndpointRouteBuilderExtensions
 
             b.RequestDelegate = context => tokenHandler.InvokeAsync(context);
         });
-    }
 
     public static void MapIngestionDebugEndpoint(this IEndpointRouteBuilder app)
         => app.MapPost("/debug", async (HttpRequest request) =>

--- a/src/LupusBytes.CS2.GameStateIntegration.Api/.editorconfig
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api/.editorconfig
@@ -1,0 +1,7 @@
+##########################################
+# Code Analyzers Rules
+##########################################
+[*.{cs,csx,cake}]
+dotnet_diagnostic.S1118.severity = none		# S1118: Utility classes should not have public constructors (needed for end to end tests)
+dotnet_diagnostic.CA1515.severity = none	# CA1515: Consider making public types internal (needed for end to end tests)
+

--- a/src/LupusBytes.CS2.GameStateIntegration.Api/Middleware/LogRequestBodyOnException.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api/Middleware/LogRequestBodyOnException.cs
@@ -4,7 +4,7 @@ namespace LupusBytes.CS2.GameStateIntegration.Api.Middleware;
 
 [SuppressMessage("Naming", "CA1711:Identifiers should not have incorrect suffix", Justification = "It's fine.")]
 [SuppressMessage("Major Code Smell", "S2166:Classes named like \"Exception\" should extend \"Exception\" or a subclass", Justification = "It's fine")]
-public class LogRequestBodyOnException(RequestDelegate next)
+internal class LogRequestBodyOnException(RequestDelegate next)
 {
     public async Task Invoke(HttpContext httpContext)
     {

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Extensions/EventExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Extensions/EventExtensions.cs
@@ -28,7 +28,8 @@ public static class EventExtensions
                 topic = $"{MqttConstants.BaseTopic}/{@event.SteamId}/round";
                 payload = r.Round is null ? string.Empty : JsonSerializer.Serialize(r.Round);
                 break;
-            default: throw new SwitchExpressionException();
+            default:
+                throw new SwitchExpressionException();
         }
 
         return new MqttMessage

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Log.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/Log.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt;

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/.editorconfig
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/.editorconfig
@@ -1,0 +1,7 @@
+##########################################
+# Code Analyzers Rules
+##########################################
+[*.{cs,csx,cake}]
+dotnet_diagnostic.S1118.severity = none		# S1118: Utility classes should not have public constructors (needed for end to end tests)
+dotnet_diagnostic.CA1515.severity = none	# CA1515: Consider making public types internal (needed for end to end tests)
+

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Fakes/FakeMqttClient.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Fakes/FakeMqttClient.cs
@@ -2,7 +2,7 @@ using LupusBytes.CS2.GameStateIntegration.Mqtt;
 
 namespace LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests.Fakes;
 
-public class FakeMqttClient : IMqttClient
+internal sealed class FakeMqttClient : IMqttClient
 {
     public Task PublishAsync(MqttMessage message, CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/AuthorizationTestWebApplication.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/AuthorizationTestWebApplication.cs
@@ -11,7 +11,7 @@ public sealed class AuthorizationTestWebApplication
 {
     public const string ExpectedToken = nameof(ExpectedToken);
 
-    private static void Main(string[] args)
+    private static void Main()
     {
         var builder = WebApplication.CreateBuilder();
         builder.Services.AddRouting();

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/PriorityOrderer.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/PriorityOrderer.cs
@@ -3,7 +3,7 @@ using Xunit.Sdk;
 
 namespace LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests.Helpers;
 
-public class PriorityOrderer : ITestCaseOrderer
+internal sealed class PriorityOrderer : ITestCaseOrderer
 {
     public const string Assembly = "LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests";
     public const string Name = $"{Assembly}.Helpers.{nameof(PriorityOrderer)}";

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/TestPriorityAttribute.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/TestPriorityAttribute.cs
@@ -1,7 +1,7 @@
 namespace LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests.Helpers;
 
 [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
-public sealed class TestPriorityAttribute(int priority) : Attribute
+internal sealed class TestPriorityAttribute(int priority) : Attribute
 {
     public int Priority { get; private set; } = priority;
 }

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/TaskHelper.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/TaskHelper.cs
@@ -1,6 +1,6 @@
 namespace LupusBytes.CS2.GameStateIntegration.Mqtt.Tests;
 
-public static class TaskHelper
+internal static class TaskHelper
 {
     public static TaskCompletionSource<bool> CompletionSourceFromTopicPublishment(
         IMqttClient mqttClient,


### PR DESCRIPTION
This PR fixes the following analyzer warnings that has emerged after GitHub Windows agents started using the .NET 9 SDK to build .NET 8 projects

- IDE0005
- IDE0055
- IDE0060
- CA1515
