### PR TITLE
Fix homeassistant cs2mqtt bridge device being connected via another unnamed device

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/Device.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/Device.cs
@@ -8,4 +8,4 @@ public record Device(
     [property: JsonPropertyName("manufacturer")] string Manufacturer,
     [property: JsonPropertyName("model")] string Model,
     [property: JsonPropertyName("sw_version")] string SoftwareVersion,
-    [property: JsonPropertyName("via_device")] string ViaDevice = "");
+    [property: JsonPropertyName("via_device"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] string? ViaDevice = null);


### PR DESCRIPTION
When sending an empty string value as "via_device", Home Assistant creates an extra "Unnamed device" with no properties.
This PR ensures that "via_device" is not sent, unless it has a value.