### PR TITLE
feat: add home-assistant add-on & repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ services:
 >⚠️ Make sure you replace the host, username, and password with values matching your setup, and that the MQTT client is not also used by another application.  
 If the broker is configured to allow anonymous access, the username and password can be omitted.
 
+## Running **cs2mqtt** as Home Assistant Add-On
+
+[![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Flupusbytes%2Fcs2mqtt)
+
+Add this repo as an add-on repository via the button above or manually by going to the Add-On Store, clicking on the top right hamburger menu, selecting Repositories and adding `https://github.com/lupusbytes/cs2mqtt`.
+
+Configure the addon just like you would for docker compose. Follow the step below to add the gamestate config to your CS2 directory but make sure to replace the `uri` with your HomeAssistant server IP and the port you configured.
+
 ### Connecting **Counter-Strike 2** to **cs2mqtt**
 
 To make **Counter-Strike 2** send game state data to **cs2mqtt**, you need to create a config file within the game's directory.

--- a/ha-addon/CHANGELOG.md
+++ b/ha-addon/CHANGELOG.md
@@ -1,0 +1,1 @@
+../CHANGELOG.md

--- a/ha-addon/README.md
+++ b/ha-addon/README.md
@@ -1,0 +1,63 @@
+# cs2mqtt
+
+Configure the addon as follows:
+
+-   `MQTT__Host`: MQTT Server IP - If you're running Mosquitto or similar via HA, add your Home Assistant server IP here.
+-   `MQTT__Port`: MQTT broker port
+-   `MQTT__UseTLS`: Set to true if your broker uses TLS (optional, default: false)
+-   `MQTT__Username`: MQTT client username (optional)
+-   `MQTT__Password`: MQTT client password (optional)
+-   `MQTT__ClientId`: MQTT client ID (optional)
+-   `MQTT__ProtocolVersion`: Allowed values are 3.1.0, 3.1.1, or 5.0.0 (optional, default: 5.0.0)
+
+### Connecting **Counter-Strike 2** to **cs2mqtt**
+
+To make **Counter-Strike 2** send game state data to **cs2mqtt**, you need to create a config file within the game's directory.
+
+If **Steam** and **Counter-Strike 2** are installed with default options, the path where you need to create your config is:
+
+```
+C:\Program Files (x86)\Steam\steamapps\common\Counter-Strike Global Offensive\game\csgo\cfg
+```
+
+Once you have located the correct path, create a new file there called **gamestate_integration_cs2mqtt.cfg** with the following content, replacing the URI part with your Home Assistant server IP:
+
+```
+"cs2mqtt"
+{
+ "uri" "http://YOUR-HOMEASSISTANT-SERVER-IP:5000"
+ "timeout" "5.0"
+ "buffer"  "0.1"
+ "throttle" "0.1"
+ "heartbeat" "60.0"
+ "data"
+ {
+   "provider"            "1"
+   "map"                 "1"
+   "round"               "1"
+   "player_id"           "1"
+   "player_state"        "1"
+ }
+}
+```
+
+> 💡 Tip
+>
+> In Windows File Explorer, it can be tricky to create a new file with a specific file extension (like `.cfg`).  
+> A simple workaround is to copy one of the many pre-existing `.cfg` files in the folder, rename it, and then replace its contents using Notepad.
+
+> ⚠️ Make sure you replace the `uri` with the IP address or hostname of the host that is running **cs2mqtt**.
+
+The next time you launch **Counter-Strike 2**, **cs2mqtt** will use the [MQTT discovery protocol](https://www.home-assistant.io/integrations/mqtt/#mqtt-discovery) to make [Home Assistant](https://www.home-assistant.io/) create an MQTT device named `CS2 STEAM_{X}:{Y}:{Z}`, matching your SteamID. On the very first game launch, the device will not have many sensors, but after joining or creating a game server, all sensors will automatically be discovered.
+
+### Limiting what game state data is sent
+
+It is possible to remove any of the following entries from the data object in **gamestate_integration_cs2mqtt.cfg**:
+
+-   `map`
+-   `round`
+-   `player_id`
+-   `player_state`
+
+This will stop **Counter-Strike 2** from sending data about the removed topics.  
+The only required entry is `provider`.

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -1,0 +1,39 @@
+{
+  "name": "cs2mqtt",
+  "version": "1.6.9",
+  "slug": "cs2mqtt",
+  "description": "Counter-Strike 2 Game State Integration to MQTT bridge",
+  "url": "https://github.com/lupusbytes/cs2mqtt",
+  "startup": "application",
+  "services": ["mqtt:need"],
+  "hassio_api": true,
+  "panel_icon": "mdi:pistol",
+  "arch": ["aarch64", "amd64"],
+  "timeout": 30,
+  "legacy": true,
+  "ports": {
+    "8080/tcp": 5000
+  },
+  "ports_description": {
+    "8080/tcp": "Game State API port"
+  },
+  "options": {
+    "MQTT__Host": "127.0.0.1",
+    "MQTT__Port": "1883",
+    "MQTT__UseTLS": false,
+    "MQTT__Username": "c2m",
+    "MQTT__Password": "password",
+    "MQTT__ClientId": "cs2mqtt",
+    "MQTT__ProtocolVersion": ["5.0.0", "3.1.1", "3.0.0"]
+  },
+  "schema": {
+    "MQTT__Host": "str",
+    "MQTT__Port": "int",
+    "MQTT__UseTLS": "bool?",
+    "MQTT__Username": "str?",
+    "MQTT__Password": "str?",
+    "MQTT__ClientId": "str?",
+    "MQTT__ProtocolVersion": "str?"
+  },
+  "image": "ghcr.io/lupusbytes/cs2mqtt"
+}

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -31,7 +31,7 @@
     "MQTT__Port": "int",
     "MQTT__UseTLS": "bool?",
     "MQTT__Username": "str?",
-    "MQTT__Password": "str?",
+    "MQTT__Password": "password?",
     "MQTT__ClientId": "str?",
     "MQTT__ProtocolVersion": "list(5.0.0|3.1.1|3.0.0)"
   },

--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -24,7 +24,7 @@
     "MQTT__Username": "c2m",
     "MQTT__Password": "password",
     "MQTT__ClientId": "cs2mqtt",
-    "MQTT__ProtocolVersion": ["5.0.0", "3.1.1", "3.0.0"]
+    "MQTT__ProtocolVersion": "5.0.0"
   },
   "schema": {
     "MQTT__Host": "str",
@@ -33,7 +33,7 @@
     "MQTT__Username": "str?",
     "MQTT__Password": "str?",
     "MQTT__ClientId": "str?",
-    "MQTT__ProtocolVersion": "str?"
+    "MQTT__ProtocolVersion": "list(5.0.0|3.1.1|3.0.0)"
   },
   "image": "ghcr.io/lupusbytes/cs2mqtt"
 }

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,0 +1,6 @@
+name: "cs2mqtt Repository"
+url: "https://github.com/davidramiro/cs2mqtt"
+maintainer: "davidramiro"
+addons:
+  cs2mqtt:
+    repository: ha-addon

--- a/repository.yaml
+++ b/repository.yaml
@@ -1,6 +1,6 @@
 name: "cs2mqtt Repository"
-url: "https://github.com/davidramiro/cs2mqtt"
-maintainer: "davidramiro"
+url: "https://github.com/lupusbytes/cs2mqtt"
+maintainer: "lupusbytes"
 addons:
   cs2mqtt:
     repository: ha-addon


### PR DESCRIPTION
Hi, 

as promised on reddit this PR makes this repo compatible as an Home Assistant Add-On repository and adds the container image as an installable add-on. I've added a truncated and edited version of the main readme as a quick start guide to the add-on documentation. It's pretty plug and play, although `127.0.0.1` won't work as MQTT host even when Home Assistant is running the broker which I have added to the docs.

Let me know what you think. If you want to try it out without merging, you can use `https://github.com/davidramiro/cs2mqtt` as an add-on repo in your Home Assistant, it will still pull your image from GHCR.