### PR TITLE
feat(homeassistant): add units for HA entity discovery

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/MapDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/MapDiscoveryMessages.cs
@@ -57,7 +57,8 @@ public class MapDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("round"),
         Icon: "mdi:counter",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "rounds"));
 
     private MqttMessage TScoreDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Team T Score",
@@ -66,7 +67,8 @@ public class MapDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.NestedJsonPropertyValue("team_t", "score"),
         Icon: "mdi:account-group",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "rounds"));
 
     private MqttMessage CTScoreDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Team CT Score",
@@ -75,5 +77,6 @@ public class MapDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.NestedJsonPropertyValue("team_ct", "score"),
         Icon: "mdi:account-group-outline",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "rounds"));
 }

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerStateDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerStateDiscoveryMessages.cs
@@ -34,7 +34,8 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("health"),
         Icon: "mdi:medical-bag",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "%"));
 
     private MqttMessage ArmorDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Armor",
@@ -43,7 +44,8 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("armor"),
         Icon: "mdi:shield",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "%"));
 
     private MqttMessage HelmetDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Helmet",
@@ -88,7 +90,8 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("money"),
         Icon: "mdi:currency-usd",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "$"));
 
     private MqttMessage RoundKillsDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Round kills",
@@ -97,7 +100,8 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("round_kills"),
         Icon: "mdi:account-alert",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "kills"));
 
     private MqttMessage RoundHeadshotsDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Round headshots",
@@ -106,7 +110,8 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("round_killhs"),
         Icon: "mdi:head-alert",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "kills"));
 
     private MqttMessage EquipmentValueDiscoveryMessage => CreateMqttMessage(new SensorConfig(
         Name: "Equipment value",
@@ -115,5 +120,6 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
         ValueTemplate: ValueTemplate.JsonPropertyValue("equip_value"),
         Icon: "mdi:currency-usd",
         device,
-        Availability: availability));
+        Availability: availability,
+        UnitOfMeasurement: "$"));
 }

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/SensorConfig.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/SensorConfig.cs
@@ -10,4 +10,7 @@ public record SensorConfig(
     [property: JsonPropertyName("icon")] string Icon,
     [property: JsonPropertyName("device")] Device Device,
     [property: JsonPropertyName("availability")] IReadOnlyCollection<Availability> Availability,
-    [property: JsonPropertyName("availability_mode")] string AvailabilityMode = "all");
+    [property: JsonPropertyName("availability_mode")] string AvailabilityMode = "all",
+    [property: JsonPropertyName("unit_of_measurement")]
+    [property: JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    string? UnitOfMeasurement = null);


### PR DESCRIPTION
Some sensors could benefit from setting units of measurement, since it allows graphing in HA rather than just showing changed strings. 

Example before:

<img width="555" height="483" alt="image" src="https://github.com/user-attachments/assets/e5e7275d-b2a0-4792-b4a8-55e54f84bfb8" />

After:

<img width="555" height="484" alt="image" src="https://github.com/user-attachments/assets/ff49370c-9dbf-4580-ac07-dafec333d09e" />
