### PR TITLE
Handle silent authentication failures

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttClient.cs
@@ -84,7 +84,7 @@ public sealed class MqttClient : IHostedService, IMqttClient, IDisposable
         .Handle<Exception>()
         .WaitAndRetryAsync(
             retryCount,
-            sleepDurationProvider: attempt => TimeSpan.FromSeconds(Math.Pow(2.5, attempt)),
+            sleepDurationProvider: attempt => options.ReconnectDelayProvider(attempt),
             onRetry: (_, timeSpan, currentAttempt, _)
                 => logger.ConnectionToMqttBrokerFailed(
                     options.Host,

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttOptions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttOptions.cs
@@ -42,4 +42,9 @@ public class MqttOptions
     /// The client ID to use when connecting to the MQTT broker.
     /// </summary>
     public string ClientId { get; set; } = Constants.ProjectName;
+
+    /// <summary>
+    /// Function that determines the delay between reconnect attempts, given the current attempt number.
+    /// </summary>
+    internal Func<int, TimeSpan> ReconnectDelayProvider { get; set; } = attempt => TimeSpan.FromSeconds(Math.Pow(2.5, attempt));
 }


### PR DESCRIPTION
When connecting to a MQTT broker with a wrong username or password, the application didn't notice or handle it.
This PR will make the MQTT client detect it and use the default reconnect/retry strategy until giving up and throwing an exception with information.