### PR TITLE
Add CS2 game device connectivity sensor

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/BinarySensorConfig.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/BinarySensorConfig.cs
@@ -11,4 +11,6 @@ public record BinarySensorConfig(
     [property: JsonPropertyName("entity_category")] string EntityCategory,
     [property: JsonPropertyName("payload_off")] string PayloadOff = "offline",
     [property: JsonPropertyName("payload_on")] string PayloadOn = "online",
-    [property: JsonPropertyName("value_template")] string ValueTemplate = "{{ value }}");
+    [property: JsonPropertyName("value_template")] string ValueTemplate = "{{ value }}",
+    [property: JsonPropertyName("availability"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    IReadOnlyCollection<Availability>? Availability = null);

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/HomeAssistantDevicePublisher.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/HomeAssistantDevicePublisher.cs
@@ -14,6 +14,7 @@ public sealed class HomeAssistantDevicePublisher(
     private const string Manufacturer = "lupusbytes";
 
     private readonly ConcurrentDictionary<SteamId64, Device> devices = [];
+    private readonly HashSet<SteamId64> publishedProviderConfigs = [];
     private readonly HashSet<SteamId64> publishedPlayerConfigs = [];
     private readonly HashSet<SteamId64> publishedPlayerStateConfigs = [];
     private readonly HashSet<SteamId64> publishedMapConfigs = [];
@@ -27,6 +28,11 @@ public sealed class HomeAssistantDevicePublisher(
 
     private Task ProcessChannelsAsync(CancellationToken stoppingToken)
         => Task.WhenAll(
+            ProcessChannelAsync(
+                ProviderChannelReader,
+                publishedProviderConfigs,
+                device => new ProviderDiscoveryMessages(device),
+                stoppingToken),
             ProcessChannelAsync(
                 PlayerChannelReader,
                 publishedPlayerConfigs,

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/MapDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/MapDiscoveryMessages.cs
@@ -7,6 +7,7 @@ public class MapDiscoveryMessages(Device device) : MqttDiscoveryMessages
     private readonly Availability[] availability =
     [
         new($"{MqttConstants.BaseTopic}/{device.Id}/map/status"),
+        new($"{MqttConstants.BaseTopic}/{device.Id}/status"),
         new(MqttConstants.SystemAvailabilityTopic),
     ];
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerDiscoveryMessages.cs
@@ -7,6 +7,7 @@ public class PlayerDiscoveryMessages(Device device) : MqttDiscoveryMessages
     private readonly Availability[] availability =
     [
         new($"{MqttConstants.BaseTopic}/{device.Id}/player/status"),
+        new($"{MqttConstants.BaseTopic}/{device.Id}/status"),
         new(MqttConstants.SystemAvailabilityTopic),
     ];
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerStateDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/PlayerStateDiscoveryMessages.cs
@@ -7,6 +7,7 @@ public class PlayerStateDiscoveryMessages(Device device) : MqttDiscoveryMessages
     private readonly Availability[] availability =
     [
         new($"{MqttConstants.BaseTopic}/{device.Id}/player-state/status"),
+        new($"{MqttConstants.BaseTopic}/{device.Id}/status"),
         new(MqttConstants.SystemAvailabilityTopic),
     ];
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/ProviderDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/ProviderDiscoveryMessages.cs
@@ -1,0 +1,27 @@
+namespace LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant;
+
+public class ProviderDiscoveryMessages(Device device) : MqttDiscoveryMessages
+{
+    private readonly string stateTopic = $"{MqttConstants.BaseTopic}/{device.Id}/status";
+    private readonly Availability[] availability =
+    [
+        new(MqttConstants.SystemAvailabilityTopic),
+    ];
+
+    protected override IEnumerable<MqttMessage> DiscoveryMessages
+    {
+        get
+        {
+            yield return ConnectionStateDiscoveryMessage;
+        }
+    }
+
+    private MqttMessage ConnectionStateDiscoveryMessage => CreateMqttMessage(new BinarySensorConfig(
+        Name: "Connection state",
+        UniqueId: $"{device.Id}_connection_state",
+        StateTopic: stateTopic,
+        Device: device,
+        DeviceClass: "connectivity",
+        EntityCategory: "diagnostic",
+        Availability: availability));
+}

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/RoundDiscoveryMessages.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/RoundDiscoveryMessages.cs
@@ -7,6 +7,7 @@ public class RoundDiscoveryMessages(Device device) : MqttDiscoveryMessages
     private readonly Availability[] availability =
     [
         new($"{MqttConstants.BaseTopic}/{device.Id}/round/status"),
+        new($"{MqttConstants.BaseTopic}/{device.Id}/status"),
         new(MqttConstants.SystemAvailabilityTopic),
     ];
 

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/GameStateMqttPublisher.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/GameStateMqttPublisher.cs
@@ -6,7 +6,7 @@ namespace LupusBytes.CS2.GameStateIntegration.Mqtt;
 
 public sealed class GameStateMqttPublisher(
     IGameStateService gameStateService,
-    IMqttClient mqttClient) : GameStateObserverService(gameStateService)
+    IMqttClient mqttClient) : GameStateWithoutProviderObserverService(gameStateService)
 {
     protected override Task ExecuteAsync(CancellationToken stoppingToken)
         => Task.WhenAll(

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/GameStateWithoutProviderObserverService.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/GameStateWithoutProviderObserverService.cs
@@ -1,0 +1,83 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Channels;
+using LupusBytes.CS2.GameStateIntegration.Events;
+using Microsoft.Extensions.Hosting;
+
+namespace LupusBytes.CS2.GameStateIntegration.Mqtt;
+
+/// <summary>
+/// This class sets up subscriptions for
+/// <see cref="PlayerEvent"/>,
+/// <see cref="PlayerStateEvent"/>,
+/// <see cref="MapEvent"/> and
+/// <see cref="RoundEvent"/>
+/// on the given <see cref="IGameStateService"/> and re-transmits all the incoming events on matching <see cref="Channel"/>s.
+/// This class does not subscribe to <see cref="ProviderEvent"/>s.
+/// Use <see cref="GameStateObserverService"/> if <see cref="ProviderEvent"/> is needed.
+/// </summary>
+public abstract class GameStateWithoutProviderObserverService :
+    BackgroundService,
+    IObserver<PlayerEvent>,
+    IObserver<PlayerStateEvent>,
+    IObserver<MapEvent>,
+    IObserver<RoundEvent>
+{
+    private readonly IDisposable[] subscriptions;
+    private readonly Channel<PlayerEvent> playerChannel;
+    private readonly Channel<PlayerStateEvent> playerStateChannel;
+    private readonly Channel<MapEvent> mapChannel;
+    private readonly Channel<RoundEvent> roundChannel;
+
+    protected static readonly BoundedChannelOptions ChannelOptions = new(1000)
+    {
+        SingleWriter = false,
+        SingleReader = true,
+        FullMode = BoundedChannelFullMode.DropOldest,
+    };
+
+    protected ChannelReader<PlayerEvent> PlayerChannelReader => playerChannel.Reader;
+    protected ChannelReader<PlayerStateEvent> PlayerStateChannelReader => playerStateChannel.Reader;
+    protected ChannelReader<MapEvent> MapChannelReader => mapChannel.Reader;
+    protected ChannelReader<RoundEvent> RoundChannelReader => roundChannel.Reader;
+
+    protected GameStateWithoutProviderObserverService(IGameStateService gameStateService)
+    {
+        playerChannel = Channel.CreateBounded<PlayerEvent>(ChannelOptions);
+        playerStateChannel = Channel.CreateBounded<PlayerStateEvent>(ChannelOptions);
+        mapChannel = Channel.CreateBounded<MapEvent>(ChannelOptions);
+        roundChannel = Channel.CreateBounded<RoundEvent>(ChannelOptions);
+
+        subscriptions =
+        [
+            gameStateService.Subscribe(this as IObserver<PlayerEvent>),
+            gameStateService.Subscribe(this as IObserver<PlayerStateEvent>),
+            gameStateService.Subscribe(this as IObserver<RoundEvent>),
+            gameStateService.Subscribe(this as IObserver<MapEvent>),
+        ];
+    }
+
+    public void OnNext(PlayerEvent value) => playerChannel.Writer.TryWrite(value);
+    public void OnNext(PlayerStateEvent value) => playerStateChannel.Writer.TryWrite(value);
+    public void OnNext(MapEvent value) => mapChannel.Writer.TryWrite(value);
+    public void OnNext(RoundEvent value) => roundChannel.Writer.TryWrite(value);
+
+    public void OnCompleted()
+    {
+    }
+
+    public void OnError(Exception error)
+    {
+    }
+
+    [SuppressMessage("Major Code Smell", "S3971:\"GC.SuppressFinalize\" should not be called", Justification = "False positive")]
+    public override void Dispose()
+    {
+        foreach (var subscription in subscriptions)
+        {
+            subscription.Dispose();
+        }
+
+        base.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/LupusBytes.CS2.GameStateIntegration/Events/ProviderEvent.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/Events/ProviderEvent.cs
@@ -1,0 +1,5 @@
+using LupusBytes.CS2.GameStateIntegration.Contracts;
+
+namespace LupusBytes.CS2.GameStateIntegration.Events;
+
+public record ProviderEvent(SteamId64 SteamId, Provider? Provider) : BaseEvent(SteamId);

--- a/src/LupusBytes.CS2.GameStateIntegration/GameState.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/GameState.cs
@@ -75,6 +75,7 @@ internal sealed class GameState(SteamId64 steamId) : ObservableGameState, IGameS
 
     public void ProcessEvent(GameStateData data)
     {
+        PushEvent(ProviderObservers, new ProviderEvent(SteamId, data.Provider));
         Player = data.Player;
         Map = data.Map;
         Round = data.Round;

--- a/src/LupusBytes.CS2.GameStateIntegration/IGameState.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/IGameState.cs
@@ -4,6 +4,7 @@ using LupusBytes.CS2.GameStateIntegration.Events;
 namespace LupusBytes.CS2.GameStateIntegration;
 
 public interface IGameState :
+    IObservable<ProviderEvent>,
     IObservable<MapEvent>,
     IObservable<RoundEvent>,
     IObservable<PlayerEvent>,

--- a/src/LupusBytes.CS2.GameStateIntegration/IGameStateService.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/IGameStateService.cs
@@ -4,6 +4,7 @@ using LupusBytes.CS2.GameStateIntegration.Events;
 namespace LupusBytes.CS2.GameStateIntegration;
 
 public interface IGameStateService :
+    IObservable<ProviderEvent>,
     IObservable<MapEvent>,
     IObservable<PlayerEvent>,
     IObservable<PlayerStateEvent>,

--- a/src/LupusBytes.CS2.GameStateIntegration/ObservableGameState.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/ObservableGameState.cs
@@ -3,6 +3,7 @@ using LupusBytes.CS2.GameStateIntegration.Events;
 namespace LupusBytes.CS2.GameStateIntegration;
 
 internal abstract class ObservableGameState :
+    IObservable<ProviderEvent>,
     IObservable<MapEvent>,
     IObservable<PlayerEvent>,
     IObservable<PlayerStateEvent>,
@@ -12,6 +13,7 @@ internal abstract class ObservableGameState :
     protected ISet<IObserver<PlayerEvent>> PlayerObservers { get; } = new HashSet<IObserver<PlayerEvent>>();
     protected ISet<IObserver<PlayerStateEvent>> PlayerStateObservers { get; } = new HashSet<IObserver<PlayerStateEvent>>();
     protected ISet<IObserver<RoundEvent>> RoundObservers { get; } = new HashSet<IObserver<RoundEvent>>();
+    protected ISet<IObserver<ProviderEvent>> ProviderObservers { get; } = new HashSet<IObserver<ProviderEvent>>();
 
     public IDisposable Subscribe(IObserver<MapEvent> observer)
     {
@@ -35,6 +37,12 @@ internal abstract class ObservableGameState :
     {
         RoundObservers.Add(observer);
         return new Unsubscriber<RoundEvent>(RoundObservers, observer);
+    }
+
+    public IDisposable Subscribe(IObserver<ProviderEvent> observer)
+    {
+        ProviderObservers.Add(observer);
+        return new Unsubscriber<ProviderEvent>(ProviderObservers, observer);
     }
 
     private sealed class Unsubscriber<TEvent>(ISet<IObserver<TEvent>> observers, IObserver<TEvent> observer) : IDisposable


### PR DESCRIPTION
<img width="509" height="476" alt="image" src="https://github.com/user-attachments/assets/922620d9-9298-4674-8f0e-98618b58961a" />

I have been toying with creating a Binary Sensor, to show if CS2 is connected to cs2mqtt.
I'm thinking it could help when creating automations, to know if the game is open or not, and not force you to pick an arbitrary sensor to test connectivty on.

My main concern with this code is the way I have to pass the provider event all the way from the ingestion endpoint to the `AvailabilityMqttPublisher`.
I can't implement it generically in the base classes, like the other events, because I do not want to send the event to all the other publishers, as the event is itself insignificant. 

What do you think about the idea, and the code @davidramiro ?