### PR TITLE
refactor(mqtt): convert polly retry policy to simple for loop

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/LupusBytes.CS2.GameStateIntegration.Mqtt.csproj
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/LupusBytes.CS2.GameStateIntegration.Mqtt.csproj
@@ -9,7 +9,6 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
       <PackageReference Include="MQTTnet" Version="5.0.1.1416" />
-      <PackageReference Include="Polly" Version="8.6.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttOptions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt/MqttOptions.cs
@@ -46,5 +46,15 @@ public class MqttOptions
     /// <summary>
     /// Function that determines the delay between reconnect attempts, given the current attempt number.
     /// </summary>
-    internal Func<int, TimeSpan> ReconnectDelayProvider { get; set; } = attempt => TimeSpan.FromSeconds(Math.Pow(2.5, attempt));
+    internal Func<int, TimeSpan> RetryDelayProvider { get; set; } = attempt => TimeSpan.FromSeconds(Math.Pow(2.5, attempt));
+
+    /// <summary>
+    /// The number of times to retry connecting initially before giving up.
+    /// </summary>
+    internal int ConnectRetryCount { get; set; } = 3;
+
+    /// <summary>
+    /// The number of times to retry reconnecting after a connection has been lost.
+    /// </summary>
+    internal int ReconnectRetryCount { get; set; } = 5;
 }


### PR DESCRIPTION
We were using Polly V7 syntax and we could not cleanly upgrade to Polly V8 without changing behavior. Polly V8 rewrite is still an option, but for now we remove Polly and use the simple loop.