### PR TITLE
docs: lower heartbeat interval in example gamestate_integration_cs2mqtt.cfg

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Once you have located the correct path, create a new file there called **gamesta
  "timeout" "5.0"
  "buffer"  "0.1"
  "throttle" "0.1"
- "heartbeat" "60.0"
+ "heartbeat" "5.0"
  "data"
  {
    "provider"            "1" 

--- a/ha-addon/README.md
+++ b/ha-addon/README.md
@@ -29,7 +29,7 @@ Once you have located the correct path, create a new file there called **gamesta
  "timeout" "5.0"
  "buffer"  "0.1"
  "throttle" "0.1"
- "heartbeat" "60.0"
+ "heartbeat" "5.0"
  "data"
  {
    "provider"            "1"


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
perf: in the documentation for `gamestate_integration_cs2mqtt.cfg`, it originally had `"heartbeat" "60.0"`, but it turns out this value also determines how long cs2 waits before sending player game state data when joining a deathmatch game or when switching from free cam to spectating a player in a casual game and more. the new recommended value is `"heartbeat" "5.0"`. please update your existing configs as you see fit.
END_COMMIT_OVERRIDE