### PR TITLE
feat: add option to ignore data from spectated players

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration/GameState.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/GameState.cs
@@ -2,7 +2,7 @@ using LupusBytes.CS2.GameStateIntegration.Contracts;
 
 namespace LupusBytes.CS2.GameStateIntegration;
 
-internal sealed class GameState(SteamId64 steamId) : ObservableGameState, IGameState
+internal sealed class GameState(SteamId64 steamId, bool ignoreSpectatedPlayers) : ObservableGameState, IGameState
 {
     private Map? map;
     private Player? player;
@@ -36,6 +36,11 @@ internal sealed class GameState(SteamId64 steamId) : ObservableGameState, IGameS
             };
         private set
         {
+            if (ignoreSpectatedPlayers && value?.SteamId64 != steamId)
+            {
+                return;
+            }
+
             var valuePlayer = value is null
                 ? null
                 : new Player(value.SteamId64, value.Name, value.Team, value.Activity);

--- a/src/LupusBytes.CS2.GameStateIntegration/GameStateOptions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/GameStateOptions.cs
@@ -1,8 +1,15 @@
+using LupusBytes.CS2.GameStateIntegration.Contracts;
+
 namespace LupusBytes.CS2.GameStateIntegration;
 
 public class GameStateOptions
 {
     public const string Section = nameof(GameStateOptions);
+
+    /// <summary>
+    /// If set to <see langword="true" />, data from players with a different <see cref="SteamId64" /> than the <see cref="Provider.SteamId64"/> will be ignored.
+    /// </summary>
+    public bool IgnoreSpectatedPlayers { get; set; } = true;
 
     /// <summary>
     /// Counter-Strike 2 client authentication token.

--- a/src/LupusBytes.CS2.GameStateIntegration/GameStateService.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/GameStateService.cs
@@ -5,11 +5,12 @@ namespace LupusBytes.CS2.GameStateIntegration;
 
 internal sealed class GameStateService : ObservableGameState, IGameStateService
 {
-    private readonly ConcurrentDictionary<SteamId64, Subscription> gameStateSubscriptions;
+    private readonly ConcurrentDictionary<SteamId64, Subscription> gameStateSubscriptions = new();
+    private readonly GameStateOptions options;
 
     public GameStateService(GameStateOptions options)
     {
-        gameStateSubscriptions = new ConcurrentDictionary<SteamId64, Subscription>();
+        this.options = options;
 
         // Start a periodic background task that will remove subscriptions that have stopped receiving events.
         // We do not receive any explicit events from Counter-Strike that we can use to determine that a provider has been disconnected.
@@ -43,7 +44,7 @@ internal sealed class GameStateService : ObservableGameState, IGameStateService
 
         var gameStateSubscription = gameStateSubscriptions.GetOrAdd(
             steamId64,
-            static (key, arg) => new Subscription(arg, new GameState(key)),
+            static (key, arg) => new Subscription(arg, new GameState(key, arg.options.IgnoreSpectatedPlayers)),
             this);
 
         gameStateSubscription.GameState.ProcessEvent(data);

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/appsettings.EndToEnd.json
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/appsettings.EndToEnd.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "GameStateOptions": {
+    "IgnoreSpectatedPlayers": false
+  }
 }

--- a/test/LupusBytes.CS2.GameStateIntegration.Tests/GameStateServiceTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Tests/GameStateServiceTest.cs
@@ -20,6 +20,7 @@ public class GameStateServiceTest
 
     [Theory, AutoNSubstituteData]
     internal void ProcessEvent_sends_events_from_multiple_providers(
+        [Frozen] GameStateOptions options,
         Provider provider1,
         Provider provider2,
         GameStateData data1,
@@ -33,6 +34,7 @@ public class GameStateServiceTest
         GameStateService sut)
     {
         // Arrange
+        options.IgnoreSpectatedPlayers = false;
         sut.Subscribe(playerObserver);
         sut.Subscribe(playerStateObserver);
         sut.Subscribe(mapObserver);
@@ -68,6 +70,7 @@ public class GameStateServiceTest
 
     [Theory, AutoNSubstituteData]
     internal void ProcessEvent_sends_events_to_multiple_observers(
+        [Frozen] GameStateOptions options,
         GameStateData data,
         IObserver<StateUpdate<Player>> playerObserver1,
         IObserver<StateUpdate<PlayerState>> playerStateObserver1,
@@ -80,6 +83,7 @@ public class GameStateServiceTest
         GameStateService sut)
     {
         // Arrange
+        options.IgnoreSpectatedPlayers = false;
         sut.Subscribe(playerObserver1);
         sut.Subscribe(playerStateObserver1);
         sut.Subscribe(mapObserver1);
@@ -107,6 +111,7 @@ public class GameStateServiceTest
 
     [Theory, AutoNSubstituteData]
     internal void ProcessEvent_does_not_send_events_on_same_data(
+        [Frozen] GameStateOptions options,
         GameStateData data,
         IObserver<StateUpdate<Player>> playerObserver,
         IObserver<StateUpdate<PlayerState>> playerStateObserver,
@@ -115,6 +120,7 @@ public class GameStateServiceTest
         GameStateService sut)
     {
         // Arrange
+        options.IgnoreSpectatedPlayers = false;
         sut.ProcessEvent(data); // Set initial properties
         sut.Subscribe(playerObserver);
         sut.Subscribe(playerStateObserver);
@@ -133,6 +139,7 @@ public class GameStateServiceTest
 
     [Theory, AutoNSubstituteData]
     internal void ProcessEvent_does_not_send_events_to_unsubscribed_observers(
+        [Frozen] GameStateOptions options,
         GameStateData data1,
         GameStateData data2,
         IObserver<StateUpdate<Player>> playerObserver,
@@ -142,6 +149,7 @@ public class GameStateServiceTest
         GameStateService sut)
     {
         // Arrange
+        options.IgnoreSpectatedPlayers = false;
         var playerSubscription = sut.Subscribe(playerObserver);
         var playerStateSubscription = sut.Subscribe(playerStateObserver);
         var mapSubscription = sut.Subscribe(mapObserver);
@@ -164,12 +172,14 @@ public class GameStateServiceTest
 
     [Theory, AutoData]
     internal void GetPlayer_returns_Player_by_SteamId(
+        [Frozen] GameStateOptions options,
         GameStateData data1,
         GameStateData data2,
         GameStateData data3,
         GameStateService sut)
     {
         // Arrange
+        options.IgnoreSpectatedPlayers = false;
         sut.ProcessEvent(data1);
         sut.ProcessEvent(data2);
         sut.ProcessEvent(data3);
@@ -289,6 +299,7 @@ public class GameStateServiceTest
         {
             TimeoutInSeconds = 0.2,
             TimeoutCleanupIntervalInSeconds = 0.5,
+            IgnoreSpectatedPlayers = false,
         };
 
         var sut = new GameStateService(options);
@@ -306,7 +317,7 @@ public class GameStateServiceTest
         sut.GetPlayer(data.Provider!.SteamId64).Should().NotBeNull();
 
         // Wait 1 second to allow the background cleanup task to perform its work.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        await Task.Delay(TimeSpan.FromSeconds(1), TestContext.Current.CancellationToken);
 
         // After the wait, the background cleanup task should have removed the provider.
         sut.GetPlayer(data.Provider.SteamId64).Should().BeNull();

--- a/test/LupusBytes.CS2.GameStateIntegration.Tests/GameStateTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Tests/GameStateTest.cs
@@ -5,8 +5,11 @@ namespace LupusBytes.CS2.GameStateIntegration.Tests;
 public class GameStateTest
 {
     [Theory, AutoData]
-    internal void ProcessEvent_sets_properties(GameStateData data, GameState sut)
+    internal void ProcessEvent_sets_properties(GameStateData data)
     {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
+
         // Act
         sut.ProcessEvent(data);
 
@@ -17,12 +20,12 @@ public class GameStateTest
     }
 
     [Theory, AutoNSubstituteData]
-    internal void ProcessEvent_sends_StateUpdate_with_Player_to_observers(
+    internal void ProcessEvent_sends_StateUpdate_with_Player_to_observers_while_IgnoreSpectatedPlayers_false(
         GameStateData data,
-        IObserver<StateUpdate<Player>> observer,
-        GameState sut)
+        IObserver<StateUpdate<Player>> observer)
     {
         // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
         sut.Subscribe(observer);
 
         // Act
@@ -38,12 +41,34 @@ public class GameStateTest
     }
 
     [Theory, AutoNSubstituteData]
-    internal void ProcessEvent_sends_StateUpdate_with_null_Player_to_observers(
+    internal void ProcessEvent_sends_StateUpdate_with_Player_to_observers_while_IgnoreSpectatedPlayers_true_and_SteamId_matches(
         GameStateData data,
-        IObserver<StateUpdate<Player>> observer,
-        GameState sut)
+        IObserver<StateUpdate<Player>> observer)
     {
         // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = data.Provider.SteamId64 } };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(1).OnNext(Arg.Is<StateUpdate<Player>>(p =>
+            p.SteamId == sut.SteamId &&
+            p.State!.SteamId64 == data.Player!.SteamId64 &&
+            p.State.Name == data.Player.Name &&
+            p.State.Team == data.Player.Team &&
+            p.State.Activity == data.Player.Activity));
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_sends_StateUpdate_with_null_Player_to_observers_while_IgnoreSpectatedPlayers_false(
+        GameStateData data,
+        IObserver<StateUpdate<Player>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
         sut.ProcessEvent(data); // Set initial properties
         data = data with { Player = null };
         sut.Subscribe(observer);
@@ -58,12 +83,51 @@ public class GameStateTest
     }
 
     [Theory, AutoNSubstituteData]
-    internal void ProcessEvent_sends_StateUpdate_with_PlayerState_to_observers(
+    internal void ProcessEvent_does_not_send_StateUpdate_with_null_Player_to_observers_while_IgnoreSpectatedPlayers_true_and_Player_is_null(
         GameStateData data,
-        IObserver<StateUpdate<PlayerState>> observer,
-        GameState sut)
+        IObserver<StateUpdate<Player>> observer)
     {
         // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = data.Provider.SteamId64 } };
+        sut.ProcessEvent(data); // Set initial properties with matching SteamId
+        data = data with { Player = null };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(0).OnNext(Arg.Is<StateUpdate<Player>>(p =>
+            p.SteamId == sut.SteamId &&
+            p.State == null));
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_does_not_send_StateUpdate_with_Player_to_observers_when_IgnoreSpectatedPlayers_true_and_SteamId_doesnt_match(
+        GameStateData data,
+        SteamId64 differentSteamId,
+        IObserver<StateUpdate<Player>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = differentSteamId.ToString() } };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(0).OnNext(Arg.Any<StateUpdate<Player>>());
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_sends_StateUpdate_with_PlayerState_to_observers_while_IgnoreSpectatedPlayers_false(
+        GameStateData data,
+        IObserver<StateUpdate<PlayerState>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
         sut.Subscribe(observer);
 
         // Act
@@ -85,12 +149,12 @@ public class GameStateTest
     }
 
     [Theory, AutoNSubstituteData]
-    internal void ProcessEvent_sends_StateUpdate_with_null_PlayerState_to_observers(
+    internal void ProcessEvent_sends_StateUpdate_with_null_PlayerState_to_observers_while_IgnoreSpectatedPlayers_false(
         GameStateData data,
-        IObserver<StateUpdate<PlayerState>> observer,
-        GameState sut)
+        IObserver<StateUpdate<PlayerState>> observer)
     {
         // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
         sut.ProcessEvent(data); // Set initial properties
         data = data with { Player = data.Player! with { State = null } };
         sut.Subscribe(observer);
@@ -102,6 +166,73 @@ public class GameStateTest
         observer.Received(1).OnNext(Arg.Is<StateUpdate<PlayerState>>(ps =>
             ps.SteamId == sut.SteamId &&
             ps.State == null));
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_sends_StateUpdate_with_PlayerState_to_observers_while_IgnoreSpectatedPlayers_true(
+        GameStateData data,
+        IObserver<StateUpdate<PlayerState>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = data.Provider.SteamId64 } };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(1).OnNext(Arg.Is<StateUpdate<PlayerState>>(ps =>
+            ps.SteamId == sut.SteamId &&
+            ps.State!.Health == data.Player!.State!.Health &&
+            ps.State.Armor == data.Player.State.Armor &&
+            ps.State.Helmet == data.Player.State.Helmet &&
+            ps.State.Flashed == data.Player.State.Flashed &&
+            ps.State.Smoked == data.Player.State.Smoked &&
+            ps.State.Burning == data.Player.State.Burning &&
+            ps.State.Money == data.Player.State.Money &&
+            ps.State.RoundKills == data.Player.State.RoundKills &&
+            ps.State.RoundKillHeadshots == data.Player.State.RoundKillHeadshots &&
+            ps.State.EquipmentValue == data.Player.State.EquipmentValue));
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_sends_StateUpdate_with_null_PlayerState_to_observers_while_IgnoreSpectatedPlayers_true(
+        GameStateData data,
+        IObserver<StateUpdate<PlayerState>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = data.Provider.SteamId64 } };
+        sut.ProcessEvent(data); // Set initial properties with matching SteamId
+        data = data with { Player = data.Player! with { State = null } };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(1).OnNext(Arg.Is<StateUpdate<PlayerState>>(ps =>
+            ps.SteamId == sut.SteamId &&
+            ps.State == null));
+    }
+
+    [Theory, AutoNSubstituteData]
+    internal void ProcessEvent_does_not_send_StateUpdate_with_PlayerState_to_observers_when_IgnoreSpectatedPlayers_true_and_SteamId_doesnt_match(
+        GameStateData data,
+        SteamId64 differentSteamId,
+        IObserver<StateUpdate<PlayerState>> observer)
+    {
+        // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: true);
+        data = data with { Player = data.Player! with { SteamId64 = differentSteamId.ToString() } };
+        sut.Subscribe(observer);
+
+        // Act
+        sut.ProcessEvent(data);
+
+        // Assert
+        observer.Received(0).OnNext(Arg.Any<StateUpdate<PlayerState>>());
     }
 
     [Theory, AutoNSubstituteData]
@@ -215,15 +346,16 @@ public class GameStateTest
 
     [Theory, AutoNSubstituteData]
     internal void ProcessEvent_does_not_send_updates_to_unsubscribed_observers(
+        SteamId64 steamId,
         GameStateData data1,
         GameStateData data2,
         IObserver<StateUpdate<Player>> playerObserver,
         IObserver<StateUpdate<PlayerState>> playerStateObserver,
         IObserver<StateUpdate<Map>> mapObserver,
-        IObserver<StateUpdate<Round>> roundObserver,
-        GameState sut)
+        IObserver<StateUpdate<Round>> roundObserver)
     {
         // Arrange
+        var sut = new GameState(steamId, ignoreSpectatedPlayers: false);
         var playerSubscription = sut.Subscribe(playerObserver);
         var playerStateSubscription = sut.Subscribe(playerStateObserver);
         var mapSubscription = sut.Subscribe(mapObserver);
@@ -254,10 +386,10 @@ public class GameStateTest
         IObserver<StateUpdate<Player>> playerObserver2,
         IObserver<StateUpdate<PlayerState>> playerStateObserver2,
         IObserver<StateUpdate<Map>> mapObserver2,
-        IObserver<StateUpdate<Round>> roundObserver2,
-        GameState sut)
+        IObserver<StateUpdate<Round>> roundObserver2)
     {
         // Arrange
+        var sut = new GameState(data.Provider!.SteamId64, ignoreSpectatedPlayers: false);
         sut.Subscribe(playerObserver1);
         sut.Subscribe(playerStateObserver1);
         sut.Subscribe(mapObserver1);


### PR DESCRIPTION
Fixes #181 
BEGIN_COMMIT_OVERRIDE
feat: add option to ignore data from spectated players. it is enabled by default and must be disabled to revert to previous behavior.
END_COMMIT_OVERRIDE