### PR TITLE
refactor: remove options suffix from configuration section name

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ It is possible to require authentication between **Counter-Strike 2** and **cs2m
 To do this, pick a password and add it as an environment variable in the **cs2mqtt** docker-compose.yml like:
 
 ```yaml
-GameStateOptions__Token: password
+GameState__Token: password
 ```
 
 Then also add the same password to **gamestate_integration_cs2mqtt.cfg** in the root object:

--- a/src/LupusBytes.CS2.GameStateIntegration/GameStateOptions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration/GameStateOptions.cs
@@ -4,7 +4,7 @@ namespace LupusBytes.CS2.GameStateIntegration;
 
 public class GameStateOptions
 {
-    public const string Section = nameof(GameStateOptions);
+    public const string Section = "GameState";
 
     /// <summary>
     /// If set to <see langword="true" />, data from players with a different <see cref="SteamId64" /> than the <see cref="Provider.SteamId64"/> will be ignored.

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/AuthorizationTestWebApplicationFactory.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/Helpers/AuthorizationTestWebApplicationFactory.cs
@@ -14,7 +14,7 @@ public sealed class AuthorizationTestWebApplicationFactory
         builder
             .ConfigureAppConfiguration(config => config.AddInMemoryCollection(
             [
-                new KeyValuePair<string, string?>("GameStateOptions:Token", ExpectedToken),
+                new KeyValuePair<string, string?>("GameState:Token", ExpectedToken),
             ]))
             .ConfigureServices((context, services) => services.AddGameStateService(context.Configuration));
 

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/appsettings.EndToEnd.json
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/appsettings.EndToEnd.json
@@ -6,7 +6,7 @@
     }
   },
   "AllowedHosts": "*",
-  "GameStateOptions": {
+  "GameState": {
     "IgnoreSpectatedPlayers": false
   }
 }


### PR DESCRIPTION
Rename the section/environment variables related to `GameStateOptions` from "GameStateOptions" to "GameState".
This change is made to streamline it and put in more in line with MqttOptions and general .NET convetions.