### PR TITLE
chore(ha-addon): add translations for new config keys and remove unused options

### DIFF
--- a/ha-addon/config.json
+++ b/ha-addon/config.json
@@ -5,10 +5,6 @@
   "description": "Counter-Strike 2 Game State Integration to MQTT bridge",
   "url": "https://github.com/lupusbytes/cs2mqtt",
   "startup": "application",
-  "services": [
-    "mqtt:need"
-  ],
-  "hassio_api": true,
   "panel_icon": "mdi:pistol",
   "arch": [
     "aarch64",

--- a/ha-addon/translations/de.yaml
+++ b/ha-addon/translations/de.yaml
@@ -1,24 +1,41 @@
 configuration:
-  MQTT__Host: 
+  GameState__IgnoreSpectatedPlayers:
+    name: Zugeschaute Spieler ignorieren
+    description: Wenn aktiviert, werden nur die eigenen Gamestate-Updates versendet. Daten von beobachteten Spielern werden ignoriert.
+  GameState__TimeoutInSeconds:
+    name: Geräte-Timeout
+    description: |
+      Anzahl der Sekunden ohne Updates oder Heartbeats, bevor das gesamte Counter-Strike-Gerät als getrennt gilt.
+      Sollte etwas länger als der Heartbeat-Wert in gamestate_integration_cs2mqtt.cfg sein.
+      Standardmäßig 60,5 Sekunden (für Kompatibilität mit älteren Versionen).
+  GameState__TimeoutCleanupIntervalInSeconds:
+    name: Intervall für Geräte-Timeout-Bereinigung
+    description: |
+      Anzahl der Sekunden zwischen jeder Ausführung von Hintergrundaufgaben, die nach getrennten Counter-Strike-Geräten sucht.
+      Standardmäßig 15 Sekunden.
+  MQTT__Host:
     name: MQTT Host
-    description: MQTT Server Host/IP - Falls ein Broker außerhalb von Home Assistant läuft, hier homeassistant.local durch Host/IP ersetzen
+    description: MQTT Server Host/IP - Falls ein Broker außerhalb von Home Assistant läuft, hier homeassistant.local durch Host/IP ersetzen.
   MQTT__Port:
     name: MQTT Port
-    description: MQTT Broker Port
+    description: MQTT Broker Port.
   MQTT__UseTLS:
     name: Use TLS
-    description: Aktivieren, wenn der Broker SSL verwendet (optional, standardmäßig deaktiviert)
+    description: Aktivieren, wenn der Broker SSL verwendet.
   MQTT__Username:
     name: MQTT Username
     description: MQTT Client Nutzername, leer lassen falls Authentifizierung deaktiviert ist.
-  MQTT__Password: 
+  MQTT__Password:
     name: MQTT Passwort
     description: MQTT Client Passwort, leer lassen falls Authentifizierung deaktiviert ist.
-  MQTT__ClientId: 
+  MQTT__ClientId:
     name: MQTT Client ID
-    description: Optional
+    description: MQTT Client-ID, Standard ist "cs2mqtt" falls leer.
   MQTT__ProtocolVersion:
     name: MQTT Protokollversion
-    description: Optional, Standard ist 5.0.0
+    description: MQTT-Protokollversion, die beim Verbinden mit dem Broker verwendet wird.
+  Logging__LogLevel__Default:
+    name: Log-Level
+    description: Standard ist "Information" wenn nicht gesetzt. "Debug" zeigt alle API-Anfragen aus Counter-Strike (viele Logs).
 network:
   8080/tcp: Game State API Port (muss in der CS2 cfg übereinstimmen)

--- a/ha-addon/translations/pt.yaml
+++ b/ha-addon/translations/pt.yaml
@@ -1,24 +1,41 @@
 configuration:
-  MQTT__Host: 
+  GameState__IgnoreSpectatedPlayers:
+    name: Ignorar jogadores especatados
+    description: Se ativado, apenas os próprios updates de estado do jogo são enviados. Dados de jogadores especatados são ignorados.
+  GameState__TimeoutInSeconds:
+    name: Timeout do dispositivo
+    description: |
+      Número de segundos sem updates ou heartbeats antes do dispositivo Counter-Strike ser considerado desconectado.
+      Deve ser um pouco maior do que o heartbeat configurado no gamestate_integration_cs2mqtt.cfg.
+      O padrão é 60,5 segundos por motivos de legado.
+  GameState__TimeoutCleanupIntervalInSeconds:
+    name: Intervalo de limpeza do timeout do dispositivo
+    description: |
+      Número de segundos entre cada execução da tarefa em segundo plano que tenta localizar dispositivos Counter-Strike desconectados.
+      O padrão é 15 segundos.
+  MQTT__Host:
     name: Host MQTT
-    description: Servidor/Host ou IP do MQTT – Se o broker estiver fora do Home Assistant, substituir homeassistant.local por Host/IP
+    description: Servidor/Host ou IP do MQTT – Se o broker estiver fora do Home Assistant, substituir homeassistant.local por Host/IP.
   MQTT__Port:
     name: Porta MQTT
-    description: Porta do broker MQTT
+    description: Porta do broker MQTT.
   MQTT__UseTLS:
     name: Usar TLS
-    description: Ativar se o broker utilizar SSL (opcional, desativado por predefinição)
+    description: Ativar se o broker utilizar SSL.
   MQTT__Username:
     name: Utilizador MQTT
     description: Nome de utilizador do cliente MQTT, deixar em branco se a autenticação estiver desativada.
-  MQTT__Password: 
+  MQTT__Password:
     name: Palavra-passe MQTT
     description: Palavra-passe do cliente MQTT, deixar em branco se a autenticação estiver desativada.
-  MQTT__ClientId: 
+  MQTT__ClientId:
     name: ID de Cliente MQTT
-    description: Opcional
+    description: ID do cliente MQTT, o padrão é "cs2mqtt" se deixar em branco.
   MQTT__ProtocolVersion:
     name: Versão do Protocolo MQTT
-    description: Opcional, a predefinição é 5.0.0
+    description: A versão do protocolo MQTT usada na ligação ao broker.
+  Logging__LogLevel__Default:
+    name: Nível de log
+    description: Padrão "Information" se não definido. "Debug" mostra todos os pedidos da API do Counter-Strike (muitos logs).
 network:
   8080/tcp: Porta Game State API (deve corresponder na configuração do CS2)


### PR DESCRIPTION
Dependency on MQTT as a HA service is not given as we might want to allow people running external brokers. No need for HASSIO API as well then.