### PR TITLE
fix(homeassistant): gracefully handle empty payloads in value_templates

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/ValueTemplate.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant/ValueTemplate.cs
@@ -3,11 +3,13 @@ namespace LupusBytes.CS2.GameStateIntegration.Mqtt.HomeAssistant;
 public static class ValueTemplate
 {
     public static string JsonPropertyValue(string propertyName)
-        => $"{{{{ value_json.{propertyName} }}}}";
+        => $"{{{{ value_json.{propertyName} if value_json is defined else none }}}}";
 
     public static string JsonPropertyValueWithFallback(string property, string fallback) =>
         $$$"""
-           {% if value_json.{{{property}}} is not none %}
+           {% if value_json is not defined %}
+             none
+           {% elif value_json.{{{property}}} is not none %}
              {{ value_json.{{{property}}} }}
            {% else %}
              {{{fallback}}}
@@ -15,11 +17,11 @@ public static class ValueTemplate
            """;
 
     public static string NestedJsonPropertyValue(string propertyName, string nestedPropertyName)
-        => $"{{{{ value_json[\"{propertyName}\"].{nestedPropertyName} }}}}";
+        => $"{{{{ value_json[\"{propertyName}\"].{nestedPropertyName} if value_json is defined else none }}}}";
 
     public static string JsonPropertyValueWithByteToPercentConversion(string propertyName)
-        => $"{{{{ (value_json.{propertyName} | int * 100 / 255) | round(0) }}}}";
+        => $"{{{{ (value_json.{propertyName} | int * 100 / 255) | round(0) if value_json is defined else none }}}}";
 
     public static string JsonPropertyValueWithByteToBoolConversion(string propertyName)
-        => $"{{{{ value_json.{propertyName} | int > 0 }}}}";
+        => $"{{{{ value_json.{propertyName} | int > 0 if value_json is defined else none }}}}";
 }


### PR DESCRIPTION
This PR will fix template variable error logs in Home Assistant
<img width="987" height="361" alt="template_error" src="https://github.com/user-attachments/assets/a3fcc7bf-4026-421a-a08c-3d1ef69cbfd0" />
