### PR TITLE
chore: remove unused and obsolete debug ingestion endpoint

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
@@ -70,19 +70,4 @@ public static class EndpointRouteBuilderExtensions
 
             b.RequestDelegate = tokenHandler.InvokeAsync;
         });
-
-    public static void MapIngestionDebugEndpoint(this IEndpointRouteBuilder app)
-        => app.MapPost("/debug", async (HttpRequest request) =>
-        {
-            string body;
-            using (var stream = new StreamReader(request.Body))
-            {
-                body = await stream.ReadToEndAsync();
-            }
-
-            Console.WriteLine("*** EVENT RECEIVED ***");
-            Console.WriteLine(body);
-
-            return TypedResults.NoContent();
-        });
 }


### PR DESCRIPTION
This debug ingestion endpoint is no longer needed for developers after the introduction of RequestBodyLogger which is automatically enabled when LogLevel is set to Debug