### PR TITLE
fix: limit ingestion request body size to possible csgsi payloads

### DIFF
--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/Constants.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/Constants.cs
@@ -1,0 +1,11 @@
+namespace LupusBytes.CS2.GameStateIntegration.Api.Endpoints;
+
+internal static class Constants
+{
+    /// <summary>
+    /// Maximum accepted request body size for the ingestion endpoint.
+    /// A real CS2 game state payload is only a few KB;
+    /// 64KiB leaves generous head-room for users who have allplayers_* enabled while preventing large-payload DoS.
+    /// </summary>
+    internal const long MaxIngestionRequestBodySizeBytes = 64 * 1024;
+}

--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/EndpointRouteBuilderExtensions.cs
@@ -50,6 +50,9 @@ public static class EndpointRouteBuilderExtensions
             return Results.NoContent();
         });
 
+        // Limit request body size to possible CSGSI payloads
+        ingestionEndpoint.WithMetadata(new RequestSizeLimitAttribute(Constants.MaxIngestionRequestBodySizeBytes));
+
         // Check if we should enable token authorization
         var token = app.ServiceProvider.GetService<GameStateOptions>()?.Token;
         if (!string.IsNullOrWhiteSpace(token))

--- a/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/LupusBytes.CS2.GameStateIntegration.Api.Endpoints.csproj
+++ b/src/LupusBytes.CS2.GameStateIntegration.Api.Endpoints/LupusBytes.CS2.GameStateIntegration.Api.Endpoints.csproj
@@ -11,4 +11,8 @@
       <ProjectReference Include="..\LupusBytes.CS2.GameStateIntegration\LupusBytes.CS2.GameStateIntegration.csproj" />
     </ItemGroup>
 
+    <ItemGroup>
+      <InternalsVisibleTo Include="LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests" />
+    </ItemGroup>
+
 </Project>

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/RequestSizeLimitTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/RequestSizeLimitTest.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Text;
+using LupusBytes.CS2.GameStateIntegration.Api.Endpoints;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+
+namespace LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests;
+
+public class RequestSizeLimitTest
+{
+    [Theory]
+    [InlineData(HttpStatusCode.BadRequest, 1)]
+    [InlineData(HttpStatusCode.BadRequest, Endpoints.Constants.MaxIngestionRequestBodySizeBytes)]
+    [InlineData(HttpStatusCode.RequestEntityTooLarge, Endpoints.Constants.MaxIngestionRequestBodySizeBytes + 1)]
+    [SuppressMessage("ReSharper", "ShortLivedHttpClient", Justification = "Not valid for this test scenario")]
+    public async Task MaxIngestionRequestBodySizeBytes_is_respected(
+        HttpStatusCode expectedStatusCode,
+        long requestBodySizeBytes)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseKestrel(k =>
+        {
+            k.Listen(IPAddress.Loopback, 0);
+        });
+
+        var app = builder.Build();
+        app.MapCS2IngestionEndpoint();
+
+        await app.StartAsync(TestContext.Current.CancellationToken);
+
+        try
+        {
+            // 'x' is U+0078, a basic ASCII character, so it's exactly 1 byte in UTF-8.
+            var body = new string('x', (int)requestBodySizeBytes);
+            using var client = new HttpClient();
+            using var content = new StringContent(body, Encoding.UTF8, "application/json");
+            using var response = await client.PostAsync(app.Urls.First(), content, TestContext.Current.CancellationToken);
+
+            response.StatusCode.Should().Be(expectedStatusCode);
+        }
+        finally
+        {
+            await app.StopAsync(TestContext.Current.CancellationToken);
+            await app.DisposeAsync();
+        }
+    }
+}


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: limit ingestion request body size to valid csgsi payloads (64kb). this change hardens the api against denial-of-service attacks. previously, an adversary could send up to 30mb of json, causing the server to spend excessive resources attempting to deserialize an oversized payload that could not have originated from a legitimate client.
END_COMMIT_OVERRIDE