### PR TITLE
test: migrate to awesomeassertions

### DIFF
--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -13,12 +13,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Atc.Test" Version="2.0.17" />
+    <PackageReference Include="Atc.Test" Version="3.0.0" />
     <PackageReference Include="AutoFixture" Version="4.18.1" />
     <PackageReference Include="AutoFixture.AutoNSubstitute" Version="4.18.1" />
     <PackageReference Include="AutoFixture.Xunit3" Version="4.19.0" />
+    <PackageReference Include="AwesomeAssertions" Version="9.4.0" />
     <PackageReference Include="coverlet.msbuild" Version="10.0.1" />
-    <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
@@ -30,6 +30,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+  </ItemGroup>
+
+  <!-- Shared code analyzers used for all tests-->
+  <ItemGroup Label="Code Analyzers">
+    <PackageReference Include="AwesomeAssertions.Analyzers" Version="9.0.8" PrivateAssets="All" />
     <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.17" PrivateAssets="All" />
   </ItemGroup>
 
@@ -37,7 +42,7 @@
     <Using Include="Atc.Test" />
     <Using Include="AutoFixture" />
     <Using Include="AutoFixture.Xunit3" />
-    <Using Include="FluentAssertions" />
+    <Using Include="AwesomeAssertions" />
     <Using Include="NSubstitute" />
     <Using Include="Xunit" />
   </ItemGroup>

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/AuthorizationTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/AuthorizationTest.cs
@@ -21,7 +21,7 @@ public class AuthorizationTest(AuthorizationTestWebApplicationFactory factory)
     private readonly HttpClient httpClient = factory.CreateClient();
 
     [Fact]
-    public async Task Post_with_valid_token_returns_successful()
+    public async Task Post_with_valid_token_returns_204()
     {
         // Arrange
         const string json = $$"""
@@ -39,7 +39,7 @@ public class AuthorizationTest(AuthorizationTestWebApplicationFactory factory)
         var response = await httpClient.PostAsync("/", payload);
 
         // Assert
-        response.Should().BeSuccessful();
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ public class AuthorizationTest(AuthorizationTestWebApplicationFactory factory)
         var response = await httpClient.PostAsync("/", payload);
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 
     [Fact]
@@ -76,6 +76,6 @@ public class AuthorizationTest(AuthorizationTestWebApplicationFactory factory)
         var response = await httpClient.PostAsync("/", payload);
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.Unauthorized);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
     }
 }

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/EndpointsTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/EndpointsTest.cs
@@ -22,7 +22,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/player");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact, Priority(2)]
@@ -32,7 +32,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/map");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact, Priority(3)]
@@ -42,7 +42,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/round");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.NotFound);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
     }
 
     [Fact, Priority(4)]
@@ -125,7 +125,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/player");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var resource = await response.Content.ReadFromJsonAsync<PlayerData>();
         resource.Should().Be(
             new PlayerData(SteamId64: "247", "Bassey", Team.T, Activity.Playing)
@@ -157,7 +157,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/map");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var resource = await response.Content.ReadFromJsonAsync<Map>();
         resource.Should().Be(
             new Map(
@@ -176,7 +176,7 @@ public class EndpointsTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/76561197981496355/round");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
         var resource = await response.Content.ReadFromJsonAsync<Round>();
         resource.Should().Be(new Round(RoundPhase.Live, WinTeam: null, Bomb: null));
     }

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/GlobalUsings.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/GlobalUsings.cs
@@ -1,2 +1,0 @@
-global using FluentAssertions;
-global using Xunit;

--- a/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/HealthCheckTest.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Api.EndToEnd.Tests/HealthCheckTest.cs
@@ -18,7 +18,7 @@ public class HealthCheckTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/alive");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("Healthy");
@@ -34,7 +34,7 @@ public class HealthCheckTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/health");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.OK);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
 
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("Healthy");
@@ -50,7 +50,7 @@ public class HealthCheckTest(TestWebApplicationFactory<Program> factory)
         var response = await httpClient.GetAsync("/health");
 
         // Assert
-        response.Should().HaveStatusCode(HttpStatusCode.ServiceUnavailable);
+        response.StatusCode.Should().Be(HttpStatusCode.ServiceUnavailable);
 
         var body = await response.Content.ReadAsStringAsync();
         body.Should().Be("Unhealthy");

--- a/test/LupusBytes.CS2.GameStateIntegration.Contracts.Tests/GlobalUsings.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Contracts.Tests/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Integration.Tests/GlobalUsings.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Integration.Tests/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/GlobalUsings.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Mqtt.Tests/GlobalUsings.cs
@@ -1,2 +1,0 @@
-global using FluentAssertions;
-global using Xunit;

--- a/test/LupusBytes.CS2.GameStateIntegration.Tests/GlobalUsings.cs
+++ b/test/LupusBytes.CS2.GameStateIntegration.Tests/GlobalUsings.cs
@@ -1,3 +1,0 @@
-global using AutoFixture.Xunit3;
-global using FluentAssertions;
-global using Xunit;


### PR DESCRIPTION
Migrate to AwesomeAssertions, an actively maintained fork of FluentAssertions, which adopted a proprietary license starting with version 8.0.